### PR TITLE
feat(msal): remove code_verifier and code_challenge related fields from the request

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -416,6 +416,8 @@ public class FlutterAppauthPlugin
         new AuthorizationRequest.Builder(
             serviceConfiguration, clientId, ResponseTypeValues.CODE, Uri.parse(redirectUrl));
 
+    authRequestBuilder.setCodeVerifier(null);
+
     if (scopes != null && !scopes.isEmpty()) {
       authRequestBuilder.setScopes(scopes);
     }

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/AppAuthIOSAuthorization.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/AppAuthIOSAuthorization.m
@@ -13,10 +13,6 @@
                   result:(FlutterResult)result
             exchangeCode:(BOOL)exchangeCode
                    nonce:(NSString *)nonce {
-  NSString *codeVerifier = [OIDAuthorizationRequest generateCodeVerifier];
-  NSString *codeChallenge =
-      [OIDAuthorizationRequest codeChallengeS256ForVerifier:codeVerifier];
-
   OIDAuthorizationRequest *request = [[OIDAuthorizationRequest alloc]
       initWithConfiguration:serviceConfiguration
                    clientId:clientId
@@ -28,9 +24,9 @@
                       nonce:nonce != nil
                                 ? nonce
                                 : [OIDAuthorizationRequest generateState]
-               codeVerifier:codeVerifier
-              codeChallenge:codeChallenge
-        codeChallengeMethod:OIDOAuthorizationRequestCodeChallengeMethodS256
+               codeVerifier:nil
+              codeChallenge:nil
+        codeChallengeMethod:nil
        additionalParameters:additionalParameters];
   UIViewController *rootViewController = [self rootViewController];
   if (exchangeCode) {
@@ -87,10 +83,6 @@
                                    setObject:authorizationResponse
                                                  .authorizationCode
                                       forKey:@"authorizationCode"];
-                               [processedResponse
-                                   setObject:authorizationResponse.request
-                                                 .codeVerifier
-                                      forKey:@"codeVerifier"];
                                [processedResponse
                                    setObject:authorizationResponse.request.nonce
                                       forKey:@"nonce"];


### PR DESCRIPTION
### Why
Our current authentication flow for Cognito does not fully implement PKCE, thus we need to remove the following parameters from the generated request:
- `code_verifier`
- `code_challenge`
- `code_challenge_method`

This is PR is required for #[MOB-135](https://tractian.atlassian.net/browse/MOB-135)

[MOB-135]: https://tractian.atlassian.net/browse/MOB-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ